### PR TITLE
Delete duplicated line in the README introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 Copyright (c) 2022 [Antmicro](https://www.antmicro.com)
 
 renode-linux-runner-action is a GitHub Action that can run scripts on Linux inside the Renode emulation.
-Linux kernel in the emulated system is configured with the [`vivid` module](https://www.kernel.org/doc/html/latest/admin-guide/media/vivid.html) enabled, which makes it possible to test V4L2 applications.
 
 ## Emulated system
 The emulated system is based on the [Buildroot 2022.08.1](https://github.com/buildroot/buildroot/tree/2022.08.1) and it runs on the RISC-V/HiFive Unleashed platform in [Renode 1.13](https://github.com/renode/renode).


### PR DESCRIPTION
Deleted duplicated information about enabling `vivid` module in the kernel