### PR TITLE
Adds gpio_mockup to the image

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,16 @@
+name: Run action - pull request
+on: [pull_request]
+
+# It is not possible to test a pull request using run_action.yml 
+# because of the action uses the deployed docker image from GHCR.
+
+jobs:
+  test-pull-request:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - run: pip install PyYAML
+
+      - name: Bash script
+        run: bash ./run-locally.sh

--- a/.github/workflows/run_action.yml
+++ b/.github/workflows/run_action.yml
@@ -14,6 +14,10 @@ jobs:
         with:
           shared-dir: ./tests
           renode-run: |
+            sh gpio.sh
             python test.py
             pip install ./pyrav4l2
             python controls-enumeration.py
+          devices: |
+            vivid
+            gpio 0 16

--- a/README.md
+++ b/README.md
@@ -5,16 +5,37 @@ renode-linux-runner-action is a GitHub Action that can run scripts on Linux insi
 
 ## Emulated system
 The emulated system is based on the [Buildroot 2022.08.1](https://github.com/buildroot/buildroot/tree/2022.08.1) and it runs on the RISC-V/HiFive Unleashed platform in [Renode 1.13](https://github.com/renode/renode).
-It contains the Linux kernel configured with the [`vivid` module](https://www.kernel.org/doc/html/latest/admin-guide/media/vivid.html) enabled and it has the following packages installed:
+It contains the Linux kernel configured with some emulated devices enabled and it has the following packages installed:
 - Python 3.10.7
 - pip 21.2.4
 - v4l2-utils 1.22.1
+- libgpiod tools 1.6.3
 
 ## Parameters
 - `shared-dir` - Path to the shared directory. Contents of this directory will be mounted in Renode. This is also the default path in which specified commands are run
 - `renode-run` - A command or a list of commands to run in Renode
+- `devices` - List of devices that should be added to the workflow
+
+### Devices syntax
+
+```yaml
+- uses: antmicro/renode-linux-runner-action@main
+  with:
+    devices: |
+      device1 param1 param2 param3 ...
+      device2 param1 param2 param3 ...
+      ...
+```
+
+### Available devices
+
+- [`vivid`](https://www.kernel.org/doc/html/latest/admin-guide/media/vivid.html) - virtual device emulating a Video4Linux device
+- [`gpio`](https://docs.kernel.org/admin-guide/gpio/gpio-mockup.html) - virtual device emulating GPIO lines. Optional parameters:
+  - left bound: GPIO line numbers will start from this number
+  - right bound: GPIO line numbers will end 1 before this number (for example, `gpio 0 64` will add 64 lines from 0 to 63)
 
 ## Usage
+
 Running a single command using the `renode-run` parameter:
 
 ```yaml
@@ -22,6 +43,7 @@ Running a single command using the `renode-run` parameter:
   with:
     shared-dir: ./shared-dir
     renode-run: command_to_run
+    devices: vivid
 ```
 
 Running multiple commands works the same way as the standard `run` command:
@@ -33,6 +55,11 @@ Running multiple commands works the same way as the standard `run` command:
     renode-run: |
       command_to_run_1
       command_to_run_2
+    renode-run: |
+      vivid
+      gpio
 ```
+
+Multiple devices can also be specified this way.
 
 The [renode-linux-runner-test](.github/workflows/run_action.yml) workflow contains an example usage of this action.

--- a/action.yml
+++ b/action.yml
@@ -6,9 +6,14 @@ inputs:
   renode-run:
     description: Command or a list of commands to run in Renode
     required: true
+  devices:
+    description: Devices to set up
+    required: false
+    default: ""
 runs:
   using: docker
   image: docker://ghcr.io/antmicro/renode-linux-runner-action
   args:
     - ${{ inputs.shared-dir }}
     - ${{ inputs.renode-run }}
+    - ${{ inputs.devices}}

--- a/extract_arguments.py
+++ b/extract_arguments.py
@@ -1,0 +1,26 @@
+import yaml
+from sys import argv, exit
+
+path = ['jobs',
+        'renode-linux-runner-test',
+        'steps',
+        2,
+        'with']
+
+def ret_arg(arg: str) -> str:
+    global path
+    path += [arg]
+
+    with open("./.github/workflows/run_action.yml", "r", encoding="utf-8") as yml:
+        obj = yaml.safe_load(yml)
+        for p in path:
+            obj = obj[p]
+    
+    return obj
+
+if __name__ == '__main__':
+
+    if len(argv) != 2:
+        exit(1)
+
+    print(ret_arg(argv[1]))

--- a/renode-linux-runner-docker/buildroot_patches/0010-hifive-unleashed-linux-build-gpio_mocup-kernel-modul.patch
+++ b/renode-linux-runner-docker/buildroot_patches/0010-hifive-unleashed-linux-build-gpio_mocup-kernel-modul.patch
@@ -1,0 +1,22 @@
+From 8f5b8b75288da8ded4fbcdd9d414168d04b5a397 Mon Sep 17 00:00:00 2001
+From: Wiktor Ogrodnik <wogrodnik@internships.antmicro.com>
+Date: Wed, 1 Mar 2023 11:59:47 +0100
+Subject: [PATCH] hifive-unleashed-linux-build-gpio_mocup-kernel-module
+
+---
+ board/sifive/hifive-unleashed/linux.config.fragment | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/board/sifive/hifive-unleashed/linux.config.fragment b/board/sifive/hifive-unleashed/linux.config.fragment
+index 5bf8635249..9bcff62bd1 100644
+--- a/board/sifive/hifive-unleashed/linux.config.fragment
++++ b/board/sifive/hifive-unleashed/linux.config.fragment
+@@ -46,3 +46,5 @@ CONFIG_IIO_TRIGGERED_EVENT=y
+ CONFIG_MEDIA_SUPPORT=m
+ CONFIG_V4L_TEST_DRIVERS=y
+ CONFIG_VIDEO_VIVID=m
++CONFIG_GPIOLIB=y
++CONFIG_GPIO_MOCKUP=m
+-- 
+2.30.2
+

--- a/renode-linux-runner-docker/buildroot_patches/0011-Add-gpiolib-to-hifive_unleashed_defconfig.patch
+++ b/renode-linux-runner-docker/buildroot_patches/0011-Add-gpiolib-to-hifive_unleashed_defconfig.patch
@@ -1,0 +1,25 @@
+From ceb4b71452891e90dc82a2d95ab10add6d3060d2 Mon Sep 17 00:00:00 2001
+From: Wiktor Ogrodnik <wogrodnik@internships.antmicro.com>
+Date: Thu, 2 Mar 2023 11:17:30 +0100
+Subject: [PATCH] Add-gpiolib-to-hifive_unleashed_defconfig
+
+---
+ configs/hifive_unleashed_defconfig | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/configs/hifive_unleashed_defconfig b/configs/hifive_unleashed_defconfig
+index 2392087f6a..ab101156cf 100644
+--- a/configs/hifive_unleashed_defconfig
++++ b/configs/hifive_unleashed_defconfig
+@@ -57,6 +57,8 @@ BR2_PACKAGE_LIBV4L_UTILS=y
+ BR2_TOOLCHAIN_BUILDROOT_WCHAR=y
+ BR2_PACKAGE_PYTHON3=y
+ BR2_PACKAGE_PYTHON_PIP=y
++BR2_PACKAGE_LIBGPIOD=y
++BR2_PACKAGE_LIBGPIOD_TOOLS=y
+ 
+ 
+ # Host tools
+-- 
+2.30.2
+

--- a/renode-linux-runner-docker/buildroot_patches/0012-Delete-default-gpio-device.patch
+++ b/renode-linux-runner-docker/buildroot_patches/0012-Delete-default-gpio-device.patch
@@ -1,0 +1,45 @@
+From 474f8638a0ce307c363ef255fc1b54e5a9b9969c Mon Sep 17 00:00:00 2001
+From: Wiktor Ogrodnik <wogrodnik@internships.antmicro.com>
+Date: Mon, 6 Mar 2023 09:52:15 +0100
+Subject: [PATCH] Delete-default-gpio-device
+
+---
+ board/sifive/hifive-unleashed/linux.config.fragment | 9 +++------
+ 1 file changed, 3 insertions(+), 6 deletions(-)
+
+diff --git a/board/sifive/hifive-unleashed/linux.config.fragment b/board/sifive/hifive-unleashed/linux.config.fragment
+index 9bcff62bd1..dc7778670b 100644
+--- a/board/sifive/hifive-unleashed/linux.config.fragment
++++ b/board/sifive/hifive-unleashed/linux.config.fragment
+@@ -1,7 +1,6 @@
+ CONFIG_HZ_100=y
+ CONFIG_GPIOLIB=y
+ CONFIG_GPIO_SYSFS=y
+-CONFIG_GPIO_SIFIVE=y
+ CONFIG_POWER_RESET_GPIO_RESTART=y
+ CONFIG_MTD=y
+ CONFIG_MTD_BLOCK=y
+@@ -15,11 +14,7 @@ CONFIG_I2C_CHARDEV=y
+ CONFIG_I2C_OCORES=y
+ CONFIG_SPI=y
+ CONFIG_SPI_SIFIVE=y
+-CONFIG_GPIOLIB=y
+-CONFIG_GPIO_SYSFS=y
+-CONFIG_GPIO_SIFIVE=y
+ CONFIG_POWER_RESET=y
+-CONFIG_POWER_RESET_GPIO_RESTART=y
+ CONFIG_USB=y
+ CONFIG_USB_XHCI_HCD=y
+ CONFIG_USB_EHCI_HCD=y
+@@ -46,5 +41,7 @@ CONFIG_IIO_TRIGGERED_EVENT=y
+ CONFIG_MEDIA_SUPPORT=m
+ CONFIG_V4L_TEST_DRIVERS=y
+ CONFIG_VIDEO_VIVID=m
+-CONFIG_GPIOLIB=y
+ CONFIG_GPIO_MOCKUP=m
++CONFIG_IKCONFIG=y
++CONFIG_PROC_FS=y
++CONFIG_PROC_DEVICETREE=y
+-- 
+2.30.2
+

--- a/renode-linux-runner-docker/payload/run-in-renode.py
+++ b/renode-linux-runner-docker/payload/run-in-renode.py
@@ -19,6 +19,8 @@ from subprocess import run, DEVNULL, CalledProcessError
 from sys import stdout as sys_stdout, exit as sys_exit, argv as sys_argv
 from time import sleep
 from re import sub as re_sub, compile as re_compile
+from dataclasses import dataclass
+from typing import Any, Protocol
 
 CR = r'\r'
 
@@ -46,6 +48,164 @@ class FilteredStdout(object):
         if attr == 'write':
             return self._write
         return getattr(self.stream, attr)
+
+
+class Action(Protocol):
+    """
+    Called by the add_devices function. Used for some
+    command when additional action is required.
+    """
+
+    """
+    If Action requirements are not satisfied this error will be printed
+    """
+    error: str
+
+    def __call__(self, *args: Any) -> str:
+        raise NotImplementedError
+
+    def check_args(self, *args: Any) -> bool:
+        """
+        Checks if the passed parameters are correct
+        """
+        raise NotImplementedError
+
+
+class GPIO_SplitDevice:
+    """
+    Replaces the number of GPIO lines with multiple
+    devices with a maximum of 32 lines each.
+    """
+    def __init__(self) -> None:
+        self.error = "the first parameter must be lower than the second"
+
+    def __call__(self, *args: str) -> str:
+
+        assert len(args) >= 3, "not enough parameters passed"
+        assert args[1].isdecimal() and args[2].isdecimal()
+
+        command: str = args[0]
+        l, r = int(args[1]), int(args[2])
+        gpio_ranges_params = []
+
+        while r - l > 32:
+            gpio_ranges_params += [l, l + 32]
+            l += 32
+
+        if l != r:
+            gpio_ranges_params += [l, r]
+
+        return [command.split("=")[0] + '=' +
+                ','.join([str(i) for i in gpio_ranges_params])]
+
+    def check_args(self, args: list[str]) -> bool:
+        return len(args) >= 2 and \
+               args[0].isdecimal() and \
+               args[1].isdecimal() and \
+               int(args[0]) < int(args[1])
+
+
+@dataclass
+class Device_Prototype:
+    """
+    Device Prototype: it stores available devices that can be added.
+    Fields:
+    ----------
+    add_commands: list[str]
+        commands that is needed to add device
+    params: list[str]
+        default parameters
+    command_action: list[tuple[str, int]]
+        defines number of parameters needed and the
+        Action itself
+    """
+    add_commands: list[str]
+    params: list[str]
+    command_action: list[tuple[Action, int]]
+
+
+@dataclass
+class Device:
+    """
+    Device Prototype: stores already added devices
+    Fields:
+    ----------
+    add_commands: list[str]
+        parsed commands to add the device
+    """
+    add_commands: list[str]
+
+
+available_devices = {
+    "vivid": Device_Prototype(
+                ["modprobe vivid"],
+                [],
+                [(None, 0)],
+            ),
+    "gpio": Device_Prototype(
+                ["modprobe gpio-mockup gpio_mockup_ranges={0},{1}"],
+                ['0', '32'],
+                [(GPIO_SplitDevice, 2)],
+            ),
+}
+
+
+added_devices: list[Device] = []
+
+
+def add_devices(devices: str):
+    """
+    Parses arguments and commands, and adds devices to the
+    `available devices` list
+    Parameters
+    ----------
+    devices: str
+        raw string from github action, syntax defined in README.md
+    """
+
+    for device in devices.splitlines():
+        device = device.split()
+        device_name = device[0]
+
+        errors_occured = False
+
+        if device_name in available_devices:
+            device_proto = available_devices[device_name]
+
+            new_device = Device([])
+
+            args = device[1:]
+            args_pointer = 0
+
+            if len(device[1:]) != len(device_proto.params):
+                print(f"WARNING: for device {device_name}, wrong number "
+                      "of parameters, replaced with the default ones.")
+                args = device_proto.params
+
+            for it, command in enumerate(device_proto.add_commands):
+
+                params_action: Action = device_proto.command_action[it][0]
+                params_list_len: int = device_proto.command_action[it][1]
+
+                if params_list_len == 0 or not params_action:
+                    new_device.add_commands.append(command)
+                    continue
+
+                params_action = params_action()
+                params = args[args_pointer:args_pointer + params_list_len]
+
+                if params_action.check_args(params):
+                    new_device.add_commands += params_action(command, *params)
+                else:
+                    print(f"ERROR: for device {device_name} {params_action.error}.")
+                    errors_occured = True
+
+                args_pointer += params_list_len
+
+            if not errors_occured:
+                added_devices.append(new_device)
+        else:
+            print(f"WARNING: Device {device_name} not found")
 
 
 def create_shared_directory_image(shared_directory: str):
@@ -126,6 +286,7 @@ def setup_renode():
         child.logfile_read = FilteredStdout(sys_stdout, CR, "")
 
         run_cmd(child, "(monitor)", "include @/hifive.resc")
+        run_cmd(child, "(hifive-unleashed)", "machine UnregisterFromParent gpio")
         run_cmd(
             child, "(hifive-unleashed)",
             "machine LoadPlatformDescriptionFromString 'virtio: Storage.VirtIOBlockDevice @ sysbus 0x100d0000 { IRQ -> plic@50 }'"
@@ -142,10 +303,14 @@ def setup_renode():
             sys_exit(1)
 
         run_cmd(child, "#", "dmesg -n 1")
-        run_cmd(child, "#", "modprobe vivid")
+        for device in added_devices:
+            for command in device.add_commands:
+                run_cmd(child, "#", command)
         run_cmd(child, "#", "mkdir /mnt/drive")
         run_cmd(child, "#", "mount /dev/vda /mnt/drive")
         run_cmd(child, "#", "cd /mnt/drive")
+        run_cmd(child, "#", "mkdir -p /sys/kernel/debug")
+        run_cmd(child, "#", "mount -t debugfs nodev /sys/kernel/debug")
 
         child.expect_exact("#")
     except px_TIMEOUT:
@@ -200,6 +365,9 @@ if __name__ == "__main__":
     if len(sys_argv) <= 2:
         print("Not enough input arguments")
         sys_exit(1)
+
+    if len(sys_argv) == 4 and sys_argv[3] != "":
+        add_devices(sys_argv[3])
 
     create_shared_directory_image(sys_argv[1])
     run_renode_in_background()

--- a/run-locally.sh
+++ b/run-locally.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+IMAGE_PATH=renode-linux-runner-docker
+DOCKERFILE_PATH=$IMAGE_PATH/Dockerfile
+
+git clone https://github.com/antmicro/pyrav4l2.git $IMAGE_PATH/pyrav4l2
+
+mkdir $IMAGE_PATH/tests
+cp -r -f tests/* $IMAGE_PATH/tests/
+
+cp $DOCKERFILE_PATH "${DOCKERFILE_PATH}.old"
+
+printf "\nRUN mkdir tests pyrav4l2      \
+        \nCOPY tests/* ./tests/         \
+        \nCOPY pyrav4l2/* ./pyrav4l2/   \
+        \nRUN mv ./pyrav4l2/ ./tests/   \
+        \n" >> $DOCKERFILE_PATH
+
+docker build -t $IMAGE_PATH      \
+             -f $DOCKERFILE_PATH \
+              $IMAGE_PATH
+
+docker run $IMAGE_PATH                 \
+           "$(python3 extract_arguments.py shared-dir)" \
+           "$(python3 extract_arguments.py renode-run)" \
+           "$(python3 extract_arguments.py devices)"
+
+mv "${DOCKERFILE_PATH}.old" $DOCKERFILE_PATH
+yes | rm -r -f $IMAGE_PATH/tests $IMAGE_PATH/pyrav4l2

--- a/tests/gpio.sh
+++ b/tests/gpio.sh
@@ -1,0 +1,27 @@
+print_result()
+{
+    if [[ $1 -eq $2 ]]; then
+        echo Done!
+    else
+        echo FAIL!
+        exit 1
+    fi
+}
+
+# test gpio_mockup getter
+
+echo 1 > /sys/kernel/debug/gpio-mockup/gpiochip0/10
+print_result $(gpioget gpiochip0 10) 1
+
+echo 0 > /sys/kernel/debug/gpio-mockup/gpiochip0/10
+print_result $(gpioget gpiochip0 10) 0
+
+
+# test gpio_mockup setter
+
+gpioset --mode=time --sec=1 -b gpiochip0 10=1
+print_result $(cat /sys/kernel/debug/gpio-mockup/gpiochip0/10) 1
+
+sleep 1
+
+print_result $(cat /sys/kernel/debug/gpio-mockup/gpiochip0/10) 0


### PR DESCRIPTION
-Adds script to start docker and tests locally
-Adds gpio_mockup to the kernel image, disables gpio native module from renode 
-Adds mechanism for adding new devices easly in run-in-renode.py script 
-Adds `devices` as new action argument