### PR TITLE
Disables run_action.yml test on pull request

### DIFF
--- a/.github/workflows/run_action.yml
+++ b/.github/workflows/run_action.yml
@@ -1,5 +1,5 @@
 name: Run action
-on: [push, pull_request]
+on: [push]
 
 jobs:
   renode-linux-runner-test:

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
     required: true
 runs:
   using: docker
-  image: docker://ghcr.io/antmicro/renode-linux-runner-docker
+  image: docker://ghcr.io/antmicro/renode-linux-runner-action
   args:
     - ${{ inputs.shared-dir }}
     - ${{ inputs.renode-run }}


### PR DESCRIPTION
-Disables run_action.yml test on pull request. Tests must be disabled because the action uses a direct path to the Docker image, and if the image changes, the tests may not be compatible.
-Renames docker image path in action.yml to correct one