### PR TITLE
Fixed buildroot version in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Copyright (c) 2022 [Antmicro](https://www.antmicro.com)
 renode-linux-runner-action is a GitHub Action that can run scripts on Linux inside the Renode emulation.
 
 ## Emulated system
-The emulated system is based on the [Buildroot 2022.08.1](https://github.com/buildroot/buildroot/tree/2022.08.1) and it runs on the RISC-V/HiFive Unleashed platform in [Renode 1.13](https://github.com/renode/renode).
+The emulated system is based on the [Buildroot 2022.11.2](https://github.com/buildroot/buildroot/tree/2022.11.2) and it runs on the RISC-V/HiFive Unleashed platform in [Renode 1.13](https://github.com/renode/renode).
 It contains the Linux kernel configured with some emulated devices enabled and it has the following packages installed:
 - Python 3.10.7
 - pip 21.2.4


### PR DESCRIPTION
The Buildroot version has been bumped to 2022.11.2, but this change is not reflected in the readme.