### PR TITLE
Action refactoring - split the run-in-renode.py

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: false
     default: ""
   python-packages:
-    description: Custom python packages that will be added to your shared dir
+    description: Custom python packages that will be sideloaded to emulated Linux
     required: false
     default: ""
   repos:
@@ -37,9 +37,8 @@ runs:
 
     - id: copy-user-path
       run: |
-        sudo mkdir -p ${GITHUB_ACTION_PATH} &&             \
-        sudo mkdir -p /mnt/user &&                         \
-        sudo cp -r "${{ inputs.shared-dir }}"/* /mnt/user
+        sudo mkdir -p ${GITHUB_ACTION_PATH}/user && \
+        sudo cp -r "${{ inputs.shared-dir }}"/* ${GITHUB_ACTION_PATH}/user
       shell: bash
 
     - id: get-images
@@ -82,9 +81,6 @@ runs:
 
     - id: test
       run: |
-        cd ${GITHUB_ACTION_PATH} && sudo python3 action/run-in-renode.py   \
-        "${{ inputs.renode-run }}"                                         \
-        "${{ inputs.devices }}"                                            \
-        "${{ inputs.python-packages }}"                                    \
-        "${{ inputs.repos }}"
+        cd ${GITHUB_ACTION_PATH} && sudo python3 action/run-in-renode.py \
+        '${{ toJSON(inputs) }}'
       shell: bash

--- a/action/common.py
+++ b/action/common.py
@@ -1,0 +1,69 @@
+# Copyright 2022-2023 Antmicro Ltd.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pexpect import spawn as px_spawn
+from re import compile as re_compile, sub as re_sub
+
+
+class FilteredStdout(object):
+    """
+    Stdout wrapper which replaces found pattern with 'replace' string.
+    """
+    def __init__(self, stream, pattern: str, replace: str):
+        """
+        Parameters
+        ----------
+        stream : stdout
+        pattern : regex pattern to match and replace with 'replace'
+        replace : string to replace found patterns
+        """
+        self.stream = stream
+        self.pattern = re_compile(pattern)
+        self.replace = replace
+
+    def _write(self, string):
+        self.stream.write(re_sub(self.pattern, self.replace, string))
+
+    def __getattr__(self, attr):
+        if attr == 'write':
+            return self._write
+        return getattr(self.stream, attr)
+
+
+def run_cmd(child_process: px_spawn,
+            output_to_expect: str,
+            cmd_to_run: str,
+            timeout: int = -1):
+    """
+    Wait for expected output in process spawned using pexpect and then run specified command
+
+    Parameters
+    ----------
+    child_process : pexpect.spawn
+        The process spawned using pexpect
+    output_to_expect : str
+        The output for that pexpect should wait before sending the specified command
+    cmd_to_run : str
+        The commands that should be run in child process after the expected output appears
+    timeout : int
+        Maximum time for waiting for expected output (default: -1 - which means inheriting timeout from specified child process)
+
+    Raises
+    ------
+    pexpect.TIMEOUT
+        If waiting for the expected output timeouts
+    """
+
+    child_process.expect_exact(output_to_expect, timeout=timeout)
+    child_process.sendline(cmd_to_run)

--- a/action/dependencies.py
+++ b/action/dependencies.py
@@ -1,0 +1,140 @@
+# Copyright 2022-2023 Antmicro Ltd.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common import run_cmd
+from pexpect import spawn as px_spawn, TIMEOUT as px_TIMEOUT
+from sys import exit as sys_exit
+from re import compile as re_compile
+from os import getcwd as os_getcwd
+from json import loads as json_loads
+
+
+# names of python packages that should be installed by default
+default_packages = []
+
+
+# python packages files ready to sideload
+downloaded_packages = []
+
+
+def get_package(child: px_spawn, package_name: str):
+    """
+    Download selected python package for riscv64 platform.
+
+    Parameters
+    ----------
+    child: px_spawn
+        pexpect spawn with shell and python virtual environment enabled
+    package_name: str
+        package to download
+    """
+
+    global downloaded_packages
+
+    child.sendline('')
+    run_cmd(child, "(venv-dir) #", f"pip download {package_name} --platform=linux_riscv64 --no-deps --progress-bar off --disable-pip-version-check")
+    child.expect_exact('(venv-dir) #')
+
+    # Removes strange ASCII control codes that appear during some 'pip download' runs.
+    ansi_escape = re_compile(r'\x1B[@-_][0-?]*[ -/]*[@-~]')
+    output_str: str = ansi_escape.sub('', child.before)
+
+    downloaded_packages += [file.split(' ')[1].split('/')[1] for file in output_str.splitlines() if file.startswith('Saved')]
+
+
+def add_packages(packages: str):
+    """
+    Download all selected python packages and their dependencies
+    for the riscv64 platform to sideload it later to emulated Linux.
+    Parameters
+    ----------
+    packages: str
+        raw string from github action, syntax defined in README.md
+    """
+
+    child = px_spawn(f'sh -c "cd {os_getcwd()};exec /bin/sh"', encoding="utf-8", timeout=60)
+
+    try:
+        child.expect_exact('#')
+        child.sendline('')
+
+        run_cmd(child, "#", "mkdir -p user/pip")
+        run_cmd(child, "#", ". ./venv-dir/bin/activate")
+
+        # Since the pip version in Ubuntu 22.04 is 22.0.2 and the first stable pip that supporting the --report flag is 23.0,
+        # pip needs to be updated in venv. This workaround may be removed later.
+        run_cmd(child, "(venv-dir) #", "pip -q install pip==23.0.1 --progress-bar off --disable-pip-version-check")
+
+        for package in default_packages + packages.splitlines():
+
+            print(f"processing: {package}")
+
+            # prepare report
+            run_cmd(child, "(venv-dir) #", f"pip install -q {package} --dry-run --report report.json --progress-bar off --disable-pip-version-check")
+            child.expect_exact("(venv-dir)")
+
+            with open("report.json", "r", encoding="utf-8") as report_file:
+                report = json_loads(report_file.read())
+
+            print(f"Packages to install: {len(report['install'])}")
+
+            for dependency in report["install"]:
+
+                dependency_name = dependency["metadata"]["name"] + "==" + dependency["metadata"]["version"] \
+                    if "vcs_info" not in dependency["download_info"] \
+                    else "git+" + dependency["download_info"]["url"] + "@" + dependency["download_info"]["vcs_info"]["commit_id"]
+                get_package(child, dependency_name)
+
+            child.sendline('')
+
+        run_cmd(child, "(venv-dir) #", "deactivate")
+
+        for package in downloaded_packages:
+            run_cmd(child, "#", f"mv {package} user/pip/")
+
+        child.expect_exact("#")
+    except px_TIMEOUT:
+        print("Timeout!")
+        sys_exit(1)
+
+
+def add_repos(repos: str):
+    """
+    Download all selected git repos to sideload it later to emulated Linux.
+
+    Parameters
+    ----------
+    repos: str
+        raw string from github action, syntax defined in README.md
+    """
+
+    for repo in repos.splitlines():
+
+        repo = repo.split(' ')
+        repo, folder = repo[0], repo[1] if len(repo) > 1 else repo[0].split('/')[-1]
+
+        print(f'Cloning {repo}' + f' to {folder}' if folder != '' else '')
+
+        child = px_spawn(f'sh -c "cd {os_getcwd()};exec /bin/sh"', encoding="utf-8", timeout=10)
+
+        try:
+            child.expect_exact('#')
+            child.sendline('')
+
+            run_cmd(child, "#", f"git clone {repo} user/{folder}")
+
+            child.expect_exact('#', timeout=3600)
+        except px_TIMEOUT:
+            print("Timeout!")
+            sys_exit(1)

--- a/action/devices.py
+++ b/action/devices.py
@@ -1,0 +1,205 @@
+# Copyright 2022-2023 Antmicro Ltd.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Protocol, Any
+from dataclasses import dataclass
+from string import hexdigits
+
+
+class Action(Protocol):
+    """
+    Called by the add_devices function. Used for some
+    command when additional action is required.
+    """
+
+    """
+    If Action requirements are not satisfied this error will be printed
+    """
+    error: str
+
+    def __call__(self, *args: Any) -> str:
+        raise NotImplementedError
+
+    def check_args(self, *args: Any) -> bool:
+        """
+        Checks if the passed parameters are correct
+        """
+        raise NotImplementedError
+
+
+class GPIO_SplitDevice:
+    """
+    Replaces the number of GPIO lines with multiple
+    devices with a maximum of 32 lines each.
+    """
+    def __init__(self) -> None:
+        self.error = "the first parameter must be lower than the second"
+
+    def __call__(self, *args: str) -> str:
+
+        assert len(args) >= 3, "not enough parameters passed"
+        assert args[1].isdecimal() and args[2].isdecimal()
+
+        command: str = args[0]
+        l, r = int(args[1]), int(args[2])
+        gpio_ranges_params = []
+
+        while r - l > 32:
+            gpio_ranges_params += [l, l + 32]
+            l += 32
+
+        if l != r:
+            gpio_ranges_params += [l, r]
+
+        return [command.split("=")[0] + '=' +
+                ','.join([str(i) for i in gpio_ranges_params])]
+
+    def check_args(self, args: list[str]) -> bool:
+        return len(args) >= 2 and \
+               args[0].isdecimal() and \
+               args[1].isdecimal() and \
+               int(args[0]) < int(args[1])
+
+
+class I2C_SetDeviceAddress:
+    """
+    Set the simulated i2c device address that is connected
+    to the i2c bus.
+    """
+    def __init__(self) -> None:
+        self.error = "the address has to be hexadecimal number between 3 and 119"
+
+    def __call__(self, *args: str) -> str:
+
+        assert len(args) >= 2, "not enough parameters passed"
+
+        command: str = args[0]
+        addr = args[1]
+
+        return [command.format(addr)]
+
+    def check_args(self, args: list[str]) -> bool:
+        return len(args) == 1 and \
+               len(args[0]) >= 3 and \
+               args[0][0:2] == '0x' and \
+               all(c in hexdigits for c in args[0][2:]) and \
+               3 <= int(args[0], 16) <= 119
+
+
+@dataclass
+class Device_Prototype:
+    """
+    Device Prototype: it stores available devices that can be added.
+    Fields:
+    ----------
+    add_commands: list[str]
+        commands that is needed to add device
+    params: list[str]
+        default parameters
+    command_action: list[tuple[Action, int]]
+        defines number of parameters needed and the
+        Action itself
+    """
+    add_commands: list[str]
+    params: list[str]
+    command_action: list[tuple[Action, int]]
+
+
+@dataclass
+class Device:
+    """
+    Device Prototype: stores already added devices
+    Fields:
+    ----------
+    add_commands: list[str]
+        parsed commands to add the device
+    """
+    add_commands: list[str]
+
+
+available_devices = {
+    "vivid": Device_Prototype(
+                ["modprobe vivid"],
+                [],
+                [(None, 0)],
+            ),
+    "gpio": Device_Prototype(
+                ["modprobe gpio-mockup gpio_mockup_ranges={0},{1}"],
+                ['0', '32'],
+                [(GPIO_SplitDevice, 2)],
+            ),
+    "i2c": Device_Prototype(
+                ["modprobe i2c-stub chip_addr={0}"],
+                ["0x1C"],
+                [(I2C_SetDeviceAddress, 1)],
+    )
+}
+
+
+added_devices: list[Device] = []
+
+
+def add_devices(devices: str):
+    """
+    Parses arguments and commands, and adds devices to the
+    `available devices` list
+    Parameters
+    ----------
+    devices: str
+        raw string from github action, syntax defined in README.md
+    """
+
+    for device in devices.splitlines():
+        device = device.split()
+        device_name = device[0]
+
+        errors_occured = False
+
+        if device_name in available_devices:
+            device_proto = available_devices[device_name]
+
+            new_device = Device([])
+
+            args = device[1:]
+            args_pointer = 0
+
+            if len(device[1:]) != len(device_proto.params):
+                print(f"WARNING: for device {device_name}, wrong number "
+                      "of parameters, replaced with the default ones.")
+                args = device_proto.params
+
+            for it, command in enumerate(device_proto.add_commands):
+
+                params_action: Action = device_proto.command_action[it][0]
+                params_list_len: int = device_proto.command_action[it][1]
+
+                if params_list_len == 0 or not params_action:
+                    new_device.add_commands.append(command)
+                    continue
+
+                params_action = params_action()
+                params = args[args_pointer:args_pointer + params_list_len]
+
+                if params_action.check_args(params):
+                    new_device.add_commands += params_action(command, *params)
+                else:
+                    print(f"ERROR: for device {device_name} {params_action.error}.")
+                    errors_occured = True
+
+                args_pointer += params_list_len
+
+            if not errors_occured:
+                added_devices.append(new_device)
+        else:
+            print(f"WARNING: Device {device_name} not found")


### PR DESCRIPTION
The run-in-renode.py script was splitted into smaller files to improve code readability and facilitate later changes.

-action arguments are now converted to json
 before being passed to the script
-small typos fixes
-replaces sendcontrol('c') with sendline('') in some places -fixes potential races with git repos sideloading
-adds 1 hour timeout to installing pip packages on target