### PR TITLE
Fixes errors with external repositories

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -93,7 +93,6 @@ runs:
 
     - id: test
       run: |
-        PWD=$(pwd) \
         cd ${GITHUB_ACTION_PATH} && sudo python3 action/run-in-renode.py \
-        '${{ toJSON(inputs) }}' "$PWD"
+        '${{ toJSON(inputs) }}' "${GITHUB_WORKSPACE}"
       shell: bash

--- a/action/dependencies.py
+++ b/action/dependencies.py
@@ -76,7 +76,7 @@ def add_packages(packages: str):
         run_cmd(child, "#", "mkdir -p pip")
         shared_directories_actions.append(
             shared_directories_action(
-                "pip",
+                f"{os_getcwd()}/pip",
                 "/var/packages",
             )
         )
@@ -154,7 +154,7 @@ def add_repos(repos: str):
 
         shared_directories_actions.append(
             shared_directories_action(
-                "repos",
+                f"{os_getcwd()}/repos",
                 "/home",
             )
         )

--- a/action/image.py
+++ b/action/image.py
@@ -76,7 +76,7 @@ def burn_rootfs_image(user_directory: str, rootfs_size: str):
         size of the rootfs in a format used by tools like truncate or auto to be calculated automatically
     """
 
-    os_makedirs("images/rootfs")
+    os_makedirs("images/rootfs/home")
 
     with tarfile_open("images/rootfs.tar") as tar:
         tar.extractall("images/rootfs")
@@ -84,7 +84,7 @@ def burn_rootfs_image(user_directory: str, rootfs_size: str):
     for dir in shared_directories_actions:
         os_makedirs(f"images/rootfs/{dir.target}", exist_ok=True)
         copytree(
-            f"{user_directory}/{dir.host}",
+            f"{user_directory}/{dir.host}" if not dir.host.startswith('/') else dir.host,
             f"images/rootfs/{dir.target}",
             dirs_exist_ok=True
         )


### PR DESCRIPTION
* Fixes the error whit chroot when no shared-dir is provided *Replaces the `pwd` command with GITHUB_WORKSPACE variable in
 composite action
* Fixed the errors with sideloading python packages on external repositories