### PR TITLE
Preparing to ship v1 version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,3 +223,18 @@ jobs:
             should-fail: true
             commands:
               - "wget example.org"
+
+  custom-task-test:
+    runs-on: ubuntu-latest
+    needs: send-to-releases
+    if: ${{ !failure() && !github.event.act }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: test
+        uses: ./
+        with:
+          shared-dirs: tests
+          tasks: |
+            tests/python_exists_image.yml
+            tests/python_exists_initramfs.yml

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ A task file is a YAML file with the following fields:
 - `name`: the only mandatory field; it is used to resolve dependencies between tasks.
 - `shell`: the name of the shell on which the commands will be executed. The action has three available shells (`host`, `target`, `renode`).
 - `requires`: the array of tasks that must be executed before this task. This list is empty by default.
-- `required-by`: the array of tasks that must be executed after this task. This list is empty by default.
+- `before`: the array of tasks that must be executed after this task, but these tasks do not have to exist. This list is empty by default.
 - `echo`: Boolean parameter. If true, the output from the shell will be printed. Default: false
 - `timeout`: Default timeout for each command. Commands can override this setting. Default: null, meaning no timeout for your commands.
 - `fail-fast`: Boolean parameter. If true, the action will return the error from the first failed command and stop. Otherwise, the action will fail at the end of the task. Default: true

--- a/action.yml
+++ b/action.yml
@@ -11,10 +11,6 @@ inputs:
     description: Paths to shared directories
     required: false
     default:
-  shared-dir:
-    description: Path to shared directory (deprecated)
-    required: false
-    default: ""
   devices:
     description: Devices to set up
     required: false

--- a/action/command.py
+++ b/action/command.py
@@ -100,7 +100,7 @@ class Task:
     name: str
     shell: str
     requires: list[str] = field(default_factory=list)
-    required_by: list[str] = field(default_factory=list)
+    before: list[str] = field(default_factory=list)
     echo: bool = False
     timeout: int | NoneType = None
     fail_fast: bool = True
@@ -126,7 +126,6 @@ class Task:
     def load_from_dict(dict: Dict[str, Any]) -> 'Task':
 
         name_map = {name: name for name in dict.keys()} | {
-            "required-by": "required_by",
             "fail-fast": "fail_fast",
             "check-exit-code": "check_exit_code",
             "should-fail": "should_fail",

--- a/action/common.py
+++ b/action/common.py
@@ -144,8 +144,8 @@ def get_file(path_or_url: str, target_path: str):
         try:
             r = requests.get(path_or_url)
             r.raise_for_status()
-        except (requests.exceptions.MissingSchema, requests.RequestException) as error:
-            error(f"Error while downloading {path_or_url} {error.response}")
+        except (requests.exceptions.MissingSchema, requests.RequestException, requests.HTTPError) as err:
+            error(f"Error while downloading {path_or_url} {err.response}")
         finally:
             with open(target_path, "wb") as fd:
                 fd.write(r.content)

--- a/action/dispatcher.py
+++ b/action/dispatcher.py
@@ -51,11 +51,11 @@ class CommandDispatcher:
             "host": ["sh", self.default_stdout, [
                 Command(command=[], expect=["#"], timeout=5),
                 Command(command=["screen -d -m renode --disable-xwt"], expect=["#"], timeout=5),
-            ], 7, "#"],
+            ], 5, "#"],
             "renode": ["telnet 127.0.0.1 1234", self.default_stdout, [
                 Command(command=[], expect=["(monitor)"], timeout=5),
                 Command(command=["emulation CreateServerSocketTerminal 3456 \"term\""], expect=["(monitor)"], timeout=5),
-            ], 5, r"\([\-a-zA-Z\d\s]+\)"],
+            ], 3, r"\([\-a-zA-Z\d\s]+\)"],
             "target": ["telnet 127.0.0.1 3456", self.default_stdout, [], 0, "#"],
         }
 
@@ -103,10 +103,10 @@ class CommandDispatcher:
                 if dependency not in self.tasks.keys():
                     error(f"Dependency {dependency} for {name} not satisfied. No such task.")
                 task_graph.add_edge(dependency, name)
-            for dependency in task.required_by:
-                if dependency not in self.tasks.keys():
-                    error(f"Dependency {name} for {dependency} not satisfied. No such task.")
-                task_graph.add_edge(name, dependency)
+
+            for dependency in task.before:
+                if dependency in self.tasks.keys():
+                    task_graph.add_edge(name, dependency)
 
         try:
             results = task_graph.topological_sorting(mode='out')

--- a/action/run-in-renode.py
+++ b/action/run-in-renode.py
@@ -107,7 +107,7 @@ if __name__ == "__main__":
 
     prepare_kernel_and_initramfs(kernel)
 
-    prepare_shared_directories(args.get("shared-dir", "") + '\n' + args.get("shared-dirs", ""))
+    prepare_shared_directories(args.get("shared-dirs", ""))
 
     devices = add_devices(args.get("devices", ""))
     python_packages = add_packages(arch, args.get("python-packages", ""))

--- a/action/shell.py
+++ b/action/shell.py
@@ -72,7 +72,7 @@ class Shell:
             else:
                 return
 
-        error(f"Shell {self.name} not responds")
+        error(f"Shell {self.name} is not responding")
 
     def _expect(self, command: Command) -> None:
         self.last_option = self.child.expect(command.expect, timeout=command.timeout)
@@ -145,6 +145,6 @@ class Shell:
             except IndexError:
                 error("Not enough options for last expect!")
             except px.EOF:
-                error(f"Shell {self.name} not responds")
+                error(f"Shell {self.name} is not responding")
             except px.TIMEOUT:
                 error("Timeout!")

--- a/action/tasks/devices/gpio.yml
+++ b/action/tasks/devices/gpio.yml
@@ -1,6 +1,6 @@
 name: device-gpio
 shell: target
-required-by: [chroot]
+before: [chroot]
 echo: true
 timeout: 10
 fail-fast: true

--- a/action/tasks/devices/i2c.yml
+++ b/action/tasks/devices/i2c.yml
@@ -1,6 +1,6 @@
 name: device-i2c
 shell: target
-required-by: [chroot]
+before: [chroot]
 echo: true
 timeout: 10
 fail-fast: true

--- a/action/tasks/devices/vivid.yml
+++ b/action/tasks/devices/vivid.yml
@@ -1,6 +1,6 @@
 name: device-vivid
 shell: target
-required-by: [chroot]
+before: [chroot]
 echo: true
 timeout: 10
 fail-fast: true

--- a/tests/python_exists_image.yml
+++ b/tests/python_exists_image.yml
@@ -1,0 +1,9 @@
+name: python-exists-image
+shell: target
+requires: [chroot]
+echo: true
+timeout: 5
+should-fail: false
+commands:
+  - command: 
+    - "sh -c \"if command -v python &> /dev/null; then echo Python available; exit 0; else echo Python not available; exit 1; fi;\""

--- a/tests/python_exists_initramfs.yml
+++ b/tests/python_exists_initramfs.yml
@@ -1,0 +1,9 @@
+name: python-exists-initramfs
+shell: target
+before: [chroot]
+echo: true
+timeout: 5
+should-fail: true
+commands:
+  - command:
+    - "sh -c \"if command -v python &> /dev/null; then echo Python available; exit 0; else echo Python not available; exit 1; fi;\""


### PR DESCRIPTION
Replaces `required_by` with `before` for grater clarity. The before dependency is no longer strict. Tasks that need to be started after the specific task do not need to exist.

Fixes `error` function override by local variable in get_file function.

Adds test that checks correctness of custom tasks

Action now catches the pexepect.EOF exception

Deletes depreacted `shared-dir` parameter (`shared-dirs` stays)