### PR TITLE
Don't use example.org for testing network

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -79,7 +79,7 @@ jobs:
           kernel: artifact/kernel-riscv64-hifive_unleashed.tar.xz
           image: artifact/image-riscv64-default.tar.xz
           renode-run: |
-            wget example.org
+            wget --spider github.com
             sh gpio.sh
             sh i2c.sh
             python pyrav4l2/.github/save_examples.py pyrav4l2/README.md
@@ -112,7 +112,7 @@ jobs:
           kernel: artifact/kernel-arm32-zynq_7000.tar.xz
           image: artifact/image-arm32-default.tar.xz
           renode-run: |
-            wget example.org
+            wget --spider github.com
             sh gpio.sh
             sh i2c.sh
             python pyrav4l2/.github/save_examples.py pyrav4l2/README.md

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -79,7 +79,7 @@ jobs:
           kernel: artifact/kernel-riscv64-hifive_unleashed.tar.xz
           image: artifact/image-riscv64-default.tar.xz
           renode-run: |
-            wget --spider github.com
+            wget --spider -S github.com 2>&1 | grep "301 Moved Permanently"
             sh gpio.sh
             sh i2c.sh
             python pyrav4l2/.github/save_examples.py pyrav4l2/README.md
@@ -112,7 +112,7 @@ jobs:
           kernel: artifact/kernel-arm32-zynq_7000.tar.xz
           image: artifact/image-arm32-default.tar.xz
           renode-run: |
-            wget --spider github.com
+            wget --spider -S github.com 2>&1 | grep "301 Moved Permanently"
             sh gpio.sh
             sh i2c.sh
             python pyrav4l2/.github/save_examples.py pyrav4l2/README.md

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -102,7 +102,9 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          path: ./
+          path: artifact/
+          pattern: artifact-*
+          merge-multiple: true
 
       - name: test
         uses: ./

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
         with:
           shared-dirs: tests
           renode-run: |
-            wget example.org
+            wget --spider github.com
             sh gpio.sh
             sh i2c.sh
             python pyrav4l2/.github/save_examples.py pyrav4l2/README.md
@@ -214,7 +214,7 @@ jobs:
           arch: arm32
           shared-dirs: tests
           renode-run: |
-            wget example.org
+            wget --spider github.com
             sh gpio.sh
             sh i2c.sh
             python pyrav4l2/.github/save_examples.py pyrav4l2/README.md
@@ -282,7 +282,7 @@ jobs:
           renode-run: |
             should-fail: true
             commands:
-              - "wget example.org"
+              - "wget --spider github.com"
 
   custom-task-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
         with:
           shared-dirs: tests
           renode-run: |
-            wget --spider github.com
+            wget --spider -S github.com 2>&1 | grep "301 Moved Permanently"
             sh gpio.sh
             sh i2c.sh
             python pyrav4l2/.github/save_examples.py pyrav4l2/README.md
@@ -214,7 +214,7 @@ jobs:
           arch: arm32
           shared-dirs: tests
           renode-run: |
-            wget --spider github.com
+            wget --spider -S github.com 2>&1 | grep "301 Moved Permanently"
             sh gpio.sh
             sh i2c.sh
             python pyrav4l2/.github/save_examples.py pyrav4l2/README.md
@@ -282,7 +282,7 @@ jobs:
           renode-run: |
             should-fail: true
             commands:
-              - "wget --spider github.com"
+              - wget --spider -S github.com 2>&1 | grep "301 Moved Permanently"
 
   custom-task-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-locally.yml
+++ b/.github/workflows/run-locally.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           shared-dirs: tests
           renode-run: |
-            wget --spider github.com
+            wget --spider -S github.com 2>&1 | grep "301 Moved Permanently"
             sh gpio.sh
             sh i2c.sh
             python pyrav4l2/.github/save_examples.py pyrav4l2/README.md

--- a/.github/workflows/run-locally.yml
+++ b/.github/workflows/run-locally.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           shared-dirs: tests
           renode-run: |
-            wget example.org
+            wget --spider github.com
             sh gpio.sh
             sh i2c.sh
             python pyrav4l2/.github/save_examples.py pyrav4l2/README.md

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ You can also set additional test parameters with [Task files](#tasks). For examp
     renode-run: |
       - should-fail: true
       - commands:
-        - wget example.org
+        - wget --spider github.com
 ```
 
 This test will complete successfully because the network is disabled in the emulated system and `wget` will return a non-zero exit code.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ You can also set additional test parameters with [Task files](#tasks). For examp
     renode-run: |
       - should-fail: true
       - commands:
-        - wget --spider github.com
+        - wget --spider -S github.com 2>&1 | grep "301 Moved Permanently"
 ```
 
 This test will complete successfully because the network is disabled in the emulated system and `wget` will return a non-zero exit code.


### PR DESCRIPTION
It fails in CI tasts, either because this site has blocked access from GitHub servers, or due to intermittent network issue outside of our control. Use github.com instead, since we're relying on it for CI anyway.

Ping doesn't work in GHA by design, hence wget is still used: https://github.com/actions/runner-images/issues/1519#issuecomment-683790054